### PR TITLE
Fixed the make file to properly build

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ CXX = g++
 CXXFLAGS = -std=c++11 -Wall -Wextra
 
 # Source files
-SRCS = ./src/main.cpp
+SRCS = ./main.cpp
 
 # Object files
 OBJS = $(SRCS:.cpp=.o)


### PR DESCRIPTION
The makefile points to a script that was originally in the /src directory, but has now been moved to the root.